### PR TITLE
fix(Dot/Pellet): resize item to fit scale

### DIFF
--- a/src/dot.cpp
+++ b/src/dot.cpp
@@ -4,8 +4,7 @@
 
 Dot::Dot(QPoint pos) : Item::Item(pos) {
   shape = QPixmap(":/res/img/item/dot.png");
-  shape.scaledToHeight(40);
-  setPixmap(shape);
+  setPixmap(shape.scaledToWidth(shape.size().width() * 2.5));
 }
 
 void Dot::Eaten() {

--- a/src/graphicengine.cpp
+++ b/src/graphicengine.cpp
@@ -1,6 +1,6 @@
 #include "graphicengine.h"
-#include "pacman.h"
 #include "ghost.h"
+#include "pacman.h"
 #include "ui_mainwindow.h"
 #include <QGraphicsGridLayout>
 #include <QGraphicsScene>
@@ -18,7 +18,7 @@ GraphicEngine::GraphicEngine(QWidget *parent)
   scene->addPixmap(QPixmap(":/res/img/maze.png").scaledToWidth(sceneWidth));
   ui->graphicsView->setScene(scene);
 
-  DrawDebugGrid();
+  // DrawDebugGrid();
 }
 
 void GraphicEngine::LoadCharacterUI(Character *character) {

--- a/src/item.h
+++ b/src/item.h
@@ -8,7 +8,7 @@
 class Item : public QObject, public QGraphicsPixmapItem {
   Q_OBJECT
 protected:
-
+  QPixmap shape;
   QPoint pos;
 
 public:

--- a/src/pellet.cpp
+++ b/src/pellet.cpp
@@ -4,8 +4,7 @@
 
 Pellet::Pellet(QPoint pos) : Item::Item(pos) {
   shape = QPixmap(":/res/img/item/pellet.png");
-  shape.scaledToHeight(40);
-  setPixmap(shape);
+  setPixmap(shape.scaledToWidth(shape.size().width() * 2.5));
 }
 
 void Pellet::Eaten() {


### PR DESCRIPTION
Previously Dot and Pellet is not resizable because of misuse QPixmap::scaledToWidth method.
Now they are resized on GUI screen.